### PR TITLE
Add changelog feature with admin interface

### DIFF
--- a/app/assets/stylesheets/changelogs.scss
+++ b/app/assets/stylesheets/changelogs.scss
@@ -1,0 +1,90 @@
+// Changelog styles
+
+.changelog-entry {
+  position: relative;
+  padding-left: 30px;
+  
+  &:before {
+    content: '';
+    position: absolute;
+    left: 10px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #e0e0e0;
+  }
+  
+  &:last-child:before {
+    bottom: 50%;
+  }
+}
+
+.version-badge {
+  display: inline-block;
+  padding: 5px 10px;
+  background-color: #333;
+  color: white;
+  border-radius: 4px;
+  font-family: monospace;
+  font-weight: bold;
+}
+
+.changelog-section {
+  position: relative;
+  
+  h3 {
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+  
+  .feature-heading {
+    color: #28a745;
+  }
+  
+  .improvement-heading {
+    color: #17a2b8;
+  }
+  
+  .bugfix-heading {
+    color: #ffc107;
+  }
+}
+
+.changelog-list {
+  list-style-type: none;
+  padding-left: 0;
+  
+  li {
+    position: relative;
+    padding-left: 20px;
+    margin-bottom: 1rem;
+    
+    &:before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 10px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: #007bff;
+    }
+  }
+}
+
+.changelog-item {
+  p {
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+  }
+}
+
+.changelog-description {
+  color: #666;
+  font-size: 0.95rem;
+  
+  p {
+    font-weight: normal;
+  }
+}

--- a/app/controllers/admin/changelog_items_controller.rb
+++ b/app/controllers/admin/changelog_items_controller.rb
@@ -1,0 +1,50 @@
+module Admin
+  class ChangelogItemsController < Admin::ApplicationController
+    before_action :set_changelog
+    before_action :set_changelog_item, only: [:edit, :update, :destroy]
+
+    def new
+      @changelog_item = @changelog.changelog_items.new
+    end
+
+    def create
+      @changelog_item = @changelog.changelog_items.new(changelog_item_params)
+      
+      if @changelog_item.save
+        redirect_to edit_admin_changelog_path(@changelog), notice: 'Changelog item was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @changelog_item.update(changelog_item_params)
+        redirect_to edit_admin_changelog_path(@changelog), notice: 'Changelog item was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @changelog_item.destroy
+      redirect_to edit_admin_changelog_path(@changelog), notice: 'Changelog item was successfully deleted.'
+    end
+
+    private
+
+    def set_changelog
+      @changelog = Changelog.find(params[:changelog_id])
+    end
+    
+    def set_changelog_item
+      @changelog_item = @changelog.changelog_items.find(params[:id])
+    end
+
+    def changelog_item_params
+      params.require(:changelog_item).permit(:title, :description, :item_type)
+    end
+  end
+end

--- a/app/controllers/admin/changelogs_controller.rb
+++ b/app/controllers/admin/changelogs_controller.rb
@@ -1,0 +1,54 @@
+module Admin
+  class ChangelogsController < Admin::ApplicationController
+    before_action :set_changelog, only: [:edit, :update, :destroy, :release]
+
+    def index
+      @changelogs = Changelog.all.order(created_at: :desc)
+    end
+
+    def new
+      @changelog = Changelog.new
+    end
+
+    def create
+      @changelog = Changelog.new(changelog_params)
+      
+      if @changelog.save
+        redirect_to admin_changelogs_path, notice: 'Changelog was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @changelog.update(changelog_params)
+        redirect_to admin_changelogs_path, notice: 'Changelog was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @changelog.destroy
+      redirect_to admin_changelogs_path, notice: 'Changelog was successfully deleted.'
+    end
+    
+    def release
+      @changelog.update(status: 'released', released_at: Time.current)
+      redirect_to admin_changelogs_path, notice: 'Changelog was successfully released.'
+    end
+
+    private
+
+    def set_changelog
+      @changelog = Changelog.find(params[:id])
+    end
+
+    def changelog_params
+      params.require(:changelog).permit(:version, :title, :status)
+    end
+  end
+end

--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -1,0 +1,11 @@
+class ChangelogsController < ApplicationController
+  def index
+    @rolling_changelog = Changelog.rolling.first
+    @released_changelogs = Changelog.released.includes(:changelog_items)
+  end
+
+  def show
+    @changelog = Changelog.find_by(version: params[:version])
+    redirect_to changelogs_path unless @changelog
+  end
+end

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -1,0 +1,18 @@
+class Changelog < ApplicationRecord
+  validates :version, presence: true
+  validates :title, presence: true
+  validates :status, presence: true, inclusion: { in: %w[rolling released] }
+  
+  has_many :changelog_items, dependent: :destroy
+  
+  scope :released, -> { where(status: 'released').order(released_at: :desc) }
+  scope :rolling, -> { where(status: 'rolling') }
+  
+  def rolling?
+    status == 'rolling'
+  end
+  
+  def released?
+    status == 'released'
+  end
+end

--- a/app/models/changelog_item.rb
+++ b/app/models/changelog_item.rb
@@ -1,0 +1,10 @@
+class ChangelogItem < ApplicationRecord
+  belongs_to :changelog
+  
+  validates :title, presence: true
+  validates :item_type, presence: true, inclusion: { in: %w[feature improvement bugfix] }
+  
+  scope :features, -> { where(item_type: 'feature') }
+  scope :improvements, -> { where(item_type: 'improvement') }
+  scope :bugfixes, -> { where(item_type: 'bugfix') }
+end

--- a/app/views/admin/changelog_items/_form.html.erb
+++ b/app/views/admin/changelog_items/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with(model: [:admin, changelog, changelog_item], local: true) do |form| %>
+  <% if changelog_item.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= pluralize(changelog_item.errors.count, "error") %> prohibited this item from being saved:</h4>
+      <ul>
+        <% changelog_item.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group mb-3">
+    <%= form.label :item_type %>
+    <%= form.select :item_type, [['Feature', 'feature'], ['Improvement', 'improvement'], ['Bug Fix', 'bugfix']], {}, class: 'form-control' %>
+    <small class="form-text text-muted">Type of changelog item</small>
+  </div>
+
+  <div class="form-group mb-3">
+    <%= form.label :title %>
+    <%= form.text_field :title, class: 'form-control', placeholder: 'e.g. You can now generate rules directly in a conversation' %>
+    <small class="form-text text-muted">A concise title for this item</small>
+  </div>
+
+  <div class="form-group mb-3">
+    <%= form.label :description %>
+    <%= form.text_area :description, class: 'form-control', rows: 5, placeholder: 'Optional detailed description' %>
+    <small class="form-text text-muted">Optional detailed description with more information</small>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/admin/changelog_items/edit.html.erb
+++ b/app/views/admin/changelog_items/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h2>Edit Changelog Item</h2>
+        <div class="card-header-actions">
+          <%= link_to 'Back to Changelog', edit_admin_changelog_path(@changelog), class: 'btn btn-secondary' %>
+        </div>
+      </div>
+      <div class="card-body">
+        <%= render 'form', changelog: @changelog, changelog_item: @changelog_item %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/changelog_items/new.html.erb
+++ b/app/views/admin/changelog_items/new.html.erb
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h2>New Changelog Item</h2>
+        <div class="card-header-actions">
+          <%= link_to 'Back to Changelog', edit_admin_changelog_path(@changelog), class: 'btn btn-secondary' %>
+        </div>
+      </div>
+      <div class="card-body">
+        <%= render 'form', changelog: @changelog, changelog_item: @changelog_item %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/changelogs/_form.html.erb
+++ b/app/views/admin/changelogs/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with(model: [:admin, changelog], local: true) do |form| %>
+  <% if changelog.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= pluralize(changelog.errors.count, "error") %> prohibited this changelog from being saved:</h4>
+      <ul>
+        <% changelog.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group mb-3">
+    <%= form.label :version %>
+    <%= form.text_field :version, class: 'form-control', placeholder: 'e.g. 0.49.x' %>
+    <small class="form-text text-muted">Version number for this changelog</small>
+  </div>
+
+  <div class="form-group mb-3">
+    <%= form.label :title %>
+    <%= form.text_field :title, class: 'form-control', placeholder: 'e.g. Rules generation, improved agent terminal and MCP images' %>
+    <small class="form-text text-muted">A descriptive title for this changelog</small>
+  </div>
+
+  <div class="form-group mb-3">
+    <%= form.label :status %>
+    <%= form.select :status, [['Rolling', 'rolling'], ['Released', 'released']], {}, class: 'form-control' %>
+    <small class="form-text text-muted">Status of this changelog</small>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/admin/changelogs/edit.html.erb
+++ b/app/views/admin/changelogs/edit.html.erb
@@ -1,0 +1,68 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h2>Edit Changelog: <%= @changelog.version %></h2>
+        <div class="card-header-actions">
+          <%= link_to 'Back to Changelogs', admin_changelogs_path, class: 'btn btn-secondary' %>
+        </div>
+      </div>
+      <div class="card-body">
+        <%= render 'form', changelog: @changelog %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row mt-4">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h2>Changelog Items</h2>
+        <div class="card-header-actions">
+          <%= link_to 'Add Item', new_admin_changelog_changelog_item_path(@changelog), class: 'btn btn-primary' %>
+        </div>
+      </div>
+      <div class="card-body">
+        <% if @changelog.changelog_items.any? %>
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Title</th>
+                <th>Description</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @changelog.changelog_items.each do |item| %>
+                <tr>
+                  <td>
+                    <% case item.item_type %>
+                    <% when 'feature' %>
+                      <span class="badge bg-success">Feature</span>
+                    <% when 'improvement' %>
+                      <span class="badge bg-info">Improvement</span>
+                    <% when 'bugfix' %>
+                      <span class="badge bg-warning">Bug Fix</span>
+                    <% end %>
+                  </td>
+                  <td><%= item.title %></td>
+                  <td><%= truncate(item.description, length: 100) if item.description.present? %></td>
+                  <td>
+                    <%= link_to 'Edit', edit_admin_changelog_changelog_item_path(@changelog, item), class: 'btn btn-sm btn-primary' %>
+                    <%= link_to 'Delete', admin_changelog_changelog_item_path(@changelog, item), method: :delete, class: 'btn btn-sm btn-danger', data: { confirm: 'Are you sure you want to delete this item?' } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <div class="alert alert-info">
+            No items have been added to this changelog yet.
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/changelogs/index.html.erb
+++ b/app/views/admin/changelogs/index.html.erb
@@ -1,0 +1,56 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h2>Changelogs</h2>
+        <div class="card-header-actions">
+          <%= link_to 'New Changelog', new_admin_changelog_path, class: 'btn btn-primary' %>
+        </div>
+      </div>
+      <div class="card-body">
+        <% if @changelogs.any? %>
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Version</th>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Items</th>
+                <th>Released At</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @changelogs.each do |changelog| %>
+                <tr>
+                  <td><%= changelog.version %></td>
+                  <td><%= changelog.title %></td>
+                  <td>
+                    <% if changelog.rolling? %>
+                      <span class="badge bg-primary">Rolling</span>
+                    <% else %>
+                      <span class="badge bg-success">Released</span>
+                    <% end %>
+                  </td>
+                  <td><%= changelog.changelog_items.count %></td>
+                  <td><%= changelog.released_at&.strftime("%Y-%m-%d %H:%M") %></td>
+                  <td>
+                    <%= link_to 'Edit', edit_admin_changelog_path(changelog), class: 'btn btn-sm btn-primary' %>
+                    <% if changelog.rolling? %>
+                      <%= link_to 'Release', release_admin_changelog_path(changelog), method: :patch, class: 'btn btn-sm btn-success', data: { confirm: 'Are you sure you want to release this changelog?' } %>
+                    <% end %>
+                    <%= link_to 'Delete', admin_changelog_path(changelog), method: :delete, class: 'btn btn-sm btn-danger', data: { confirm: 'Are you sure you want to delete this changelog?' } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <div class="alert alert-info">
+            No changelogs have been created yet.
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/changelogs/new.html.erb
+++ b/app/views/admin/changelogs/new.html.erb
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h2>New Changelog</h2>
+        <div class="card-header-actions">
+          <%= link_to 'Back to Changelogs', admin_changelogs_path, class: 'btn btn-secondary' %>
+        </div>
+      </div>
+      <div class="card-body">
+        <%= render 'form', changelog: @changelog %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/changelogs/index.html.erb
+++ b/app/views/changelogs/index.html.erb
@@ -1,0 +1,169 @@
+<div class="container mt-5">
+  <h1 class="mb-4">Changelog</h1>
+  
+  <% if @rolling_changelog %>
+    <div class="changelog-entry mb-5">
+      <div class="d-flex align-items-center mb-3">
+        <div class="version-badge me-3">
+          <%= @rolling_changelog.version %>
+        </div>
+        <h2 class="mb-0"><%= @rolling_changelog.title %></h2>
+        <span class="ms-3 badge bg-primary">Rolling</span>
+      </div>
+      
+      <% if @rolling_changelog.changelog_items.any? %>
+        <div class="changelog-content">
+          <% if @rolling_changelog.changelog_items.features.any? %>
+            <div class="changelog-section mb-4">
+              <h3 class="feature-heading">Automated and improved features</h3>
+              <ul class="changelog-list">
+                <% @rolling_changelog.changelog_items.features.each do |item| %>
+                  <li>
+                    <div class="changelog-item">
+                      <p><%= item.title %></p>
+                      <% if item.description.present? %>
+                        <div class="changelog-description">
+                          <%= simple_format(item.description) %>
+                        </div>
+                      <% end %>
+                    </div>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+          
+          <% if @rolling_changelog.changelog_items.improvements.any? %>
+            <div class="changelog-section mb-4">
+              <h3 class="improvement-heading">Improvements</h3>
+              <ul class="changelog-list">
+                <% @rolling_changelog.changelog_items.improvements.each do |item| %>
+                  <li>
+                    <div class="changelog-item">
+                      <p><%= item.title %></p>
+                      <% if item.description.present? %>
+                        <div class="changelog-description">
+                          <%= simple_format(item.description) %>
+                        </div>
+                      <% end %>
+                    </div>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+          
+          <% if @rolling_changelog.changelog_items.bugfixes.any? %>
+            <div class="changelog-section mb-4">
+              <h3 class="bugfix-heading">Bug Fixes</h3>
+              <ul class="changelog-list">
+                <% @rolling_changelog.changelog_items.bugfixes.each do |item| %>
+                  <li>
+                    <div class="changelog-item">
+                      <p><%= item.title %></p>
+                      <% if item.description.present? %>
+                        <div class="changelog-description">
+                          <%= simple_format(item.description) %>
+                        </div>
+                      <% end %>
+                    </div>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p>No changes have been added to this version yet.</p>
+      <% end %>
+    </div>
+  <% end %>
+  
+  <% if @released_changelogs.any? %>
+    <h2 class="mb-4">Previous Releases</h2>
+    
+    <% @released_changelogs.each do |changelog| %>
+      <div class="changelog-entry mb-5">
+        <div class="d-flex align-items-center mb-3">
+          <div class="version-badge me-3">
+            <%= changelog.version %>
+          </div>
+          <h2 class="mb-0"><%= changelog.title %></h2>
+          <small class="ms-3 text-muted">Released on <%= changelog.released_at.strftime("%B %d, %Y") %></small>
+        </div>
+        
+        <% if changelog.changelog_items.any? %>
+          <div class="changelog-content">
+            <% if changelog.changelog_items.features.any? %>
+              <div class="changelog-section mb-4">
+                <h3 class="feature-heading">Features</h3>
+                <ul class="changelog-list">
+                  <% changelog.changelog_items.features.each do |item| %>
+                    <li>
+                      <div class="changelog-item">
+                        <p><%= item.title %></p>
+                        <% if item.description.present? %>
+                          <div class="changelog-description">
+                            <%= simple_format(item.description) %>
+                          </div>
+                        <% end %>
+                      </div>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+            
+            <% if changelog.changelog_items.improvements.any? %>
+              <div class="changelog-section mb-4">
+                <h3 class="improvement-heading">Improvements</h3>
+                <ul class="changelog-list">
+                  <% changelog.changelog_items.improvements.each do |item| %>
+                    <li>
+                      <div class="changelog-item">
+                        <p><%= item.title %></p>
+                        <% if item.description.present? %>
+                          <div class="changelog-description">
+                            <%= simple_format(item.description) %>
+                          </div>
+                        <% end %>
+                      </div>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+            
+            <% if changelog.changelog_items.bugfixes.any? %>
+              <div class="changelog-section mb-4">
+                <h3 class="bugfix-heading">Bug Fixes</h3>
+                <ul class="changelog-list">
+                  <% changelog.changelog_items.bugfixes.each do |item| %>
+                    <li>
+                      <div class="changelog-item">
+                        <p><%= item.title %></p>
+                        <% if item.description.present? %>
+                          <div class="changelog-description">
+                            <%= simple_format(item.description) %>
+                          </div>
+                        <% end %>
+                      </div>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <p>No changes were recorded for this version.</p>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+  
+  <% if !@rolling_changelog && @released_changelogs.empty? %>
+    <div class="alert alert-info">
+      No changelog entries available yet.
+    </div>
+  <% end %>
+</div>

--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -1,0 +1,85 @@
+<div class="container mt-5">
+  <div class="mb-4">
+    <a href="<%= changelogs_path %>" class="btn btn-outline-secondary">&larr; Back to all changelogs</a>
+  </div>
+  
+  <div class="changelog-entry mb-5">
+    <div class="d-flex align-items-center mb-3">
+      <div class="version-badge me-3">
+        <%= @changelog.version %>
+      </div>
+      <h1 class="mb-0"><%= @changelog.title %></h1>
+      <% if @changelog.rolling? %>
+        <span class="ms-3 badge bg-primary">Rolling</span>
+      <% else %>
+        <small class="ms-3 text-muted">Released on <%= @changelog.released_at.strftime("%B %d, %Y") %></small>
+      <% end %>
+    </div>
+    
+    <% if @changelog.changelog_items.any? %>
+      <div class="changelog-content">
+        <% if @changelog.changelog_items.features.any? %>
+          <div class="changelog-section mb-4">
+            <h3 class="feature-heading">Features</h3>
+            <ul class="changelog-list">
+              <% @changelog.changelog_items.features.each do |item| %>
+                <li>
+                  <div class="changelog-item">
+                    <p><%= item.title %></p>
+                    <% if item.description.present? %>
+                      <div class="changelog-description">
+                        <%= simple_format(item.description) %>
+                      </div>
+                    <% end %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        
+        <% if @changelog.changelog_items.improvements.any? %>
+          <div class="changelog-section mb-4">
+            <h3 class="improvement-heading">Improvements</h3>
+            <ul class="changelog-list">
+              <% @changelog.changelog_items.improvements.each do |item| %>
+                <li>
+                  <div class="changelog-item">
+                    <p><%= item.title %></p>
+                    <% if item.description.present? %>
+                      <div class="changelog-description">
+                        <%= simple_format(item.description) %>
+                      </div>
+                    <% end %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        
+        <% if @changelog.changelog_items.bugfixes.any? %>
+          <div class="changelog-section mb-4">
+            <h3 class="bugfix-heading">Bug Fixes</h3>
+            <ul class="changelog-list">
+              <% @changelog.changelog_items.bugfixes.each do |item| %>
+                <li>
+                  <div class="changelog-item">
+                    <p><%= item.title %></p>
+                    <% if item.description.present? %>
+                      <div class="changelog-description">
+                        <%= simple_format(item.description) %>
+                      </div>
+                    <% end %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p>No changes were recorded for this version.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,6 +36,8 @@ html
             li class="nav-item"
               = link_to '时间线', archives_path, class: 'nav-link'
             li class="nav-item"
+              = link_to '更新日志', changelogs_path, class: 'nav-link'
+            li class="nav-item"
               = link_to '关于', about_path, class: 'nav-link'
             li class="nav-item"
               a class="nav-link" href=archives_path

--- a/app/views/shared/admin/_sidebar.html.slim
+++ b/app/views/shared/admin/_sidebar.html.slim
@@ -31,3 +31,9 @@ aside.app-sidebar.bg-body-secondary.shadow data-bs-theme="dark"
           = link_to admin_labels_path, class: "nav-link #{admin_active_for(admin_labels_path, current_path)}" do
             i.nav-icon.fas.fa-list
             span 标签管理
+            
+        li.nav-header 更新日志
+        li.nav-item
+          = link_to admin_changelogs_path, class: "nav-link #{admin_active_for(admin_changelogs_path, current_path)}" do
+            i.nav-icon.fas.fa-clipboard-list
+            span 更新日志管理

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
 
   resources :archives, only: [:index]
   resources :photos, only: [:create]
+  
+  resources :changelogs, only: [:index]
+  get '/changelogs/:version', to: 'changelogs#show', as: :changelog
 
   get '/about', to: 'home#about'
 
@@ -40,7 +43,13 @@ Rails.application.routes.draw do
 
     resources :all_comments, only: [:index, :destroy]
     resources :labels
-
+    
+    resources :changelogs do
+      resources :changelog_items, except: [:index, :show]
+      member do
+        patch :release
+      end
+    end
 
     root to: 'dashboard#index'
   end

--- a/db/migrate/20250417000001_create_changelogs.rb
+++ b/db/migrate/20250417000001_create_changelogs.rb
@@ -1,0 +1,14 @@
+class CreateChangelogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :changelogs do |t|
+      t.string :version, null: false
+      t.string :title, null: false
+      t.string :status, null: false, default: 'rolling'
+      t.datetime :released_at
+
+      t.timestamps
+    end
+    
+    add_index :changelogs, :version, unique: true
+  end
+end

--- a/db/migrate/20250417000002_create_changelog_items.rb
+++ b/db/migrate/20250417000002_create_changelog_items.rb
@@ -1,0 +1,12 @@
+class CreateChangelogItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :changelog_items do |t|
+      t.references :changelog, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :description
+      t.string :item_type, null: false, default: 'feature'
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR adds a changelog feature to the blog application, allowing administrators to create and manage changelogs and changelog items. The feature includes:

- Changelog model with version, title, status, and released_at fields
- ChangelogItem model with title, description, and item_type fields
- Admin interface for managing changelogs and changelog items
- Public interface for viewing changelogs
- Navigation links in both public and admin interfaces

## UI Implementation
The UI follows the design shown in the screenshot, with:
- Version number display
- Title for each changelog
- Status indicator (Rolling/Released)
- Categorized changelog items (features, improvements, bugfixes)
- Timeline visualization

## How to Test
1. Run database migrations
2. Access the admin interface at /admin/changelogs
3. Create a new changelog with version and title
4. Add changelog items with different types
5. View the public changelog page at /changelogs

## Screenshots
N/A (Implementation matches the provided reference design)